### PR TITLE
Use 'getattr' to get class attribute, DRY 'get_after' and 'get_before…

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -1,6 +1,6 @@
 __author__ = 'jamiebrew'
 
-import ngram
+from ngram import Ngram
 import string
 import math
 import operator
@@ -10,11 +10,11 @@ from collections import Counter
 """
 a corpus represents information about a text as a tree indexed by string
 	* each entry in the tree is an ngram object
-	* the key for a multi-word ngram is the space-separated words in the ngram	
+	* the key for a multi-word ngram is the space-separated words in the ngram
 """
 class Corpus(object):
 
-    def __init__(self, text, name, max_ngram_size = 2, sort_attribute = "FREQUENCY", foresight = 0, hindsight = 2, wordcount_criterion = 1):
+    def __init__(self, text, name, max_ngram_size = 2, sort_attribute = "frequency", foresight = 0, hindsight = 2, wordcount_criterion = 1):
         self.wordcount = 0
         self.wordcount_criterion = wordcount_criterion
         self.foresight = foresight
@@ -111,7 +111,7 @@ class Corpus(object):
         if str in tree:
             tree[str].count += 1
         else:
-            tree[str] = ngram.Ngram(str)
+            tree[str] = Ngram(str)
             tree[str].after = [{} for i in range(0,self.hindsight)]
             tree[str].before = [{} for i in range(0,self.foresight)]
 
@@ -183,7 +183,7 @@ class Corpus(object):
                     # crude function for privileging larger n-grams and closer contexts
                     weight = (10**n_gram_size)/(10**reach)
                     for tuple in after_previous:
-                        key = tuple[0].string
+                        key = tuple[0]
                         value = tuple[1] * weight
                         if len(key.split(' ')) == 1:
                             if key not in suggestions:
@@ -214,7 +214,7 @@ class Corpus(object):
         baseline_weight = 0.00000001
         for key in self.tree:
             n_gram = self.tree[key]
-            value = baseline_weight * n_gram.get_attribute(self.sort_attribute)
+            value = baseline_weight * getattr(n_gram, self.sort_attribute)
             if len(key.split(' ')) == 1:
                 if key not in suggestions:
                     suggestions[key] = value

--- a/corpus.py
+++ b/corpus.py
@@ -203,7 +203,7 @@ class Corpus(object):
                     # crude function for privileging larger n-grams and closer contexts
                     weight = (10**n_gram_size)/(10**reach)
                     for tuple in before_next:
-                        key = tuple[0].string
+                        key = tuple[0]
                         value = tuple[1] * weight
                         if len(key.split(' ')) == 1:
                             if key not in suggestions:

--- a/ngram.py
+++ b/ngram.py
@@ -11,7 +11,7 @@ class Ngram(object):
         self.after = []                 # list of dictionaries
         self.before = []                # list of dictionaries
         self.frequency = 0              # normalized rate of occurrence
-        self.sig_score = 0                    # significance score
+        self.sig_score = 0              # significance score
         self.rhymes = {}
 
     def __str__(self):
@@ -19,48 +19,33 @@ class Ngram(object):
 
     def __repr__(self):
         return self.string
-    
+
     def __len__(self):
         return len(self.string)
 
-    # returns top n words occurring distance after this ngram
-    def get_after(self, distance=1, n=20, sort_attribute="COUNT"):
-        if distance <= len(self.after):
-            dictionary = self.after[distance-1]
-            #print 'top %s words occuring %s after "%s":' % (n, distance, self.string)
-            word_list = [] #TODO: cleaner way to do this
-            for key in dictionary:
-                if sort_attribute == "COUNT":
-                    word_list.append((dictionary[key], dictionary[key].count))
-                elif sort_attribute == "FREQUENCY":
-                    word_list.append((dictionary[key], dictionary[key].frequency))
-                elif sort_attribute == "SIG_SCORE":
-                    word_list.append((dictionary[key], dictionary[key].sig_score))
-            return list(reversed(sorted(word_list, key=lambda tup: tup[1])))[0:n]
-        else:
-            return []
+    # returns top n words occuring distance after this ngram
+    def get_after(self, distance=1, n=20, sort_attribute="count"):
+        return self._get_ngram_and_attribute(distance, n, sort_attribute, True)
 
-    # returns top n words occurring distance before this ngram
-    def get_before(self, distance=1, n=20, sort_attribute="COUNT"):
-        if distance <= len(self.before):
-            dictionary = self.before[distance-1]
-            #print 'top %s words occuring %s before "%s":' % (n, distance, self.string)
-            word_list = [] #TODO: cleaner way to do this
-            for key in dictionary:
-                if sort_attribute == "COUNT":
-                    word_list.append((dictionary[key], dictionary[key].count))
-                elif sort_attribute == "FREQUENCY":
-                    word_list.append((dictionary[key], dictionary[key].frequency))
-                elif sort_attribute == "SIG_SCORE":
-                    word_list.append((dictionary[key], dictionary[key].sig_score))
-            return list(reversed(sorted(word_list, key=lambda tup: tup[1])))[0:n]
-        else:
-            return[]
+    # returns top n words occuring distance before this ngram
+    def get_before(self, distance=1, n=20, sort_attribute="count"):
+        return self._get_ngram_and_attribute(distance, n, sort_attribute, False)
 
-    def get_attribute(self, sort_attribute):
-        if sort_attribute == "COUNT":
-            return self.count
-        elif sort_attribute == "FREQUENCY":
-            return self.frequency
-        elif sort_attribute == "SIG_SCORE":
-            return self.sig_score
+    def _get_ngram_and_attribute(self, distance, n, sort_attribute, is_after):
+        distance -= 1
+        dictionary = self.after[distance] if is_after else self.before[distance]
+
+        return list(
+            reversed(
+                sorted(
+                    map(
+                        lambda (string, ngram): (
+                            string,
+                            getattr(ngram, sort_attribute)
+                        ),
+                        dictionary.iteritems()
+                    ),
+                    key=lambda tuple: tuple[1]
+                )
+            )
+        )[0:n]


### PR DESCRIPTION
A little bit of refactoring to use the getattr (https://docs.python.org/2/library/functions.html#getattr) method instead of a switch statement. The get_after and get_before methods are now functional one-liners and no longer store the Ngram object, just the necessary attributes. It's a little less readable and I'm open to reverting it.
